### PR TITLE
Refactor methods to return Result for single mut out primitive  Revised methods that have a single mutable out primitive to return Result<primitive, AeronCError> instead of requiring the user to pass a mutable reference. This enhances API usability and consistency by encapsulating return values and error handling in a single return type.

### DIFF
--- a/rusteron-client/README.md
+++ b/rusteron-client/README.md
@@ -180,7 +180,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if result < msg.len() as i64 {
                 eprintln!("ERROR: failed to send message {:?}", AeronCError::from_code(result as i32));
             } else {
-                buffer.data_mut().write_all(&msg).unwrap();
+                buffer.data().write_all(&msg).unwrap();
                 buffer.commit().unwrap();
                 println!("Sent message [result={}]", result);
             }

--- a/rusteron-client/README.md
+++ b/rusteron-client/README.md
@@ -15,6 +15,7 @@ The **rusteron-client** module acts as a Rust wrapper around the Aeron C client 
 - **Subscription**: Receive messages from Aeron channels.
 - **Callbacks**: Handle events such as new publications, new subscriptions, and errors.
 - **Automatic Resource Management**: Resources are automatically managed, except for handlers, which require manual management.
+- Updated methods with a single mutable out primitive to return `Result<primitive, AeronCError>`, enhancing usability and consistency by encapsulating return values and error handling.
 
 ## General Patterns
 

--- a/rusteron-client/src/lib.rs
+++ b/rusteron-client/src/lib.rs
@@ -229,7 +229,7 @@ mod tests {
                             AeronCError::from_code(result as i32)
                         );
                     } else {
-                        buffer.data_mut().write_all(&msg).unwrap();
+                        buffer.data().write_all(&msg).unwrap();
                         buffer.commit().unwrap();
                         println!("send message [result={}]", result);
                     }
@@ -306,7 +306,7 @@ mod tests {
              registration_id: i64,
              counter_id: i32| {
                 println!("on counter {:?} {counters_reader:?}, registration_id={registration_id}, counter_id={counter_id}, value={}", counters_reader.get_counter_label(counter_id, 1000), counters_reader.addr(counter_id));
-                assert_eq!(counters_reader.get_counter_registration_id(counter_id).unwrap(), registration_id);
+                assert_eq!(counters_reader.counter_registration_id(counter_id).unwrap(), registration_id);
                 if let Ok(label) = counters_reader.get_counter_label(counter_id, 1000) {
                     if label == "test_counter" {
                         found_counter = true;

--- a/rusteron-code-gen/src/aeron_custom.rs
+++ b/rusteron-code-gen/src/aeron_custom.rs
@@ -13,65 +13,6 @@ impl AeronCounter {
 
 impl AeronCountersReader {
     #[inline]
-    #[doc = "Get the registration id assigned to a counter."]
-    #[doc = ""]
-    #[doc = " \n**param** counters_reader representing the this pointer."]
-    #[doc = " \n**param** counter_id      for which the registration id is requested."]
-    #[doc = " \n**param** registration_id pointer for value to be set on success."]
-    #[doc = " \n**return** -1 on failure, 0 on success."]
-    pub fn get_counter_registration_id(&self, counter_id: i32) -> Result<i64, AeronCError> {
-        let mut result = 0;
-        self.counter_registration_id(counter_id, &mut result)?;
-        Ok(result)
-    }
-    #[inline]
-    #[doc = "Get the owner id assigned to a counter which will typically be the client id."]
-    #[doc = ""]
-    #[doc = " \n**param** counters_reader representing the this pointer."]
-    #[doc = " \n**param** counter_id      for which the owner id is requested."]
-    #[doc = " \n**param** owner_id        pointer for value to be set on success."]
-    #[doc = " \n**return** -1 on failure, 0 on success."]
-    pub fn get_counter_owner_id(&self, counter_id: i32) -> Result<i64, AeronCError> {
-        let mut result = 0;
-        self.counter_owner_id(counter_id, &mut result)?;
-        Ok(result)
-    }
-    #[inline]
-    #[doc = "Get the reference id assigned to a counter which will typically be the registration id of an associated Image,"]
-    #[doc = " Subscription, Publication, etc."]
-    #[doc = ""]
-    #[doc = " \n**param** counters_reader representing the this pointer."]
-    #[doc = " \n**param** counter_id      for which the reference id is requested."]
-    #[doc = " \n**param** reference_id    pointer for value to be set on success."]
-    #[doc = " \n**return** -1 on failure, 0 on success."]
-    pub fn get_counter_reference_id(&self, counter_id: i32) -> Result<i64, AeronCError> {
-        let mut result = 0;
-        self.counter_reference_id(counter_id, &mut result)?;
-        Ok(result)
-    }
-    #[inline]
-    #[doc = "Get the state for a counter."]
-    #[doc = ""]
-    #[doc = " \n**param** counters_reader that contains the counter"]
-    #[doc = " \n**param** counter_id to find"]
-    #[doc = " \n**param** state out pointer for the current state to be stored in."]
-    #[doc = " \n**return** -1 on failure, 0 on success."]
-    pub fn get_counter_state(&self, counter_id: i32) -> Result<i32, AeronCError> {
-        let mut result = 0;
-        Ok(self.counter_state(counter_id, &mut result)?)
-    }
-    #[inline]
-    #[doc = "Get the type id for a counter."]
-    #[doc = ""]
-    #[doc = " \n**param** counters_reader that contains the counter"]
-    #[doc = " \n**param** counter_id to find"]
-    #[doc = " \n**param** type id out pointer for the current state to be stored in."]
-    #[doc = " \n**return** -1 on failure, 0 on success."]
-    pub fn get_counter_type_id(&self, counter_id: i32) -> Result<i32, AeronCError> {
-        let mut result = 0;
-        Ok(self.counter_type_id(counter_id, &mut result)?)
-    }
-    #[inline]
     #[doc = "Get the label for a counter."]
     #[doc = ""]
     #[doc = " \n**param** counters_reader that contains the counter"]


### PR DESCRIPTION
Refactor methods to return Result for single mut out primitive

Revised methods that have a single mutable out primitive to return Result<primitive, AeronCError> instead of requiring the user to pass a mutable reference. This enhances API usability and consistency by encapsulating return values and error handling in a single return type.