### PR TITLE
Fix build issues with different version libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,6 @@ jobs:
           cd rusteron-media-driver/aeron/ && pwd && git submodule update --init --recursive --checkout && git reset --hard && git clean -fdx && git status && cd -
           cd rusteron-rb/aeron/ && pwd && git status && cd -
           
-          cargo clean --workspace
+          cargo clean
           cargo build --workspace  --verbose ${{ env.feature-flags }}
           cargo test --workspace --verbose --all --all-targets ${{ env.feature-flags }} -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,6 @@ jobs:
           cd rusteron-media-driver/aeron/ && pwd && git submodule update --init --recursive --checkout && git reset --hard && git clean -fdx && git status && cd -
           cd rusteron-rb/aeron/ && pwd && git status && cd -
           
-          cargo clean
-          cargo build --verbose ${{ env.feature-flags }}
-          cargo test --verbose --all --all-targets ${{ env.feature-flags }} -- --nocapture
+          cargo clean --workspace
+          cargo build --workspace  --verbose ${{ env.feature-flags }}
+          cargo test --workspace --verbose --all --all-targets ${{ env.feature-flags }} -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-#        os: [ubuntu-latest, macos-latest]
-#        features: [default, static]
+#        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
+        features: [default, static]
         # using static as different modules have different versions of aeron which don't seem to play nicely
-        features: [static]
+#        features: [static]
         #        rust-version: ["stable", "stable 6 months ago"]
         rust-version: ["stable"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 #        os: [ubuntu-latest, macos-latest]
-        features: [default, static]
-#        features: [static]
+#        features: [default, static]
+        # using static as different modules have different versions of aeron which don't seem to play nicely
+        features: [static]
         #        rust-version: ["stable", "stable 6 months ago"]
         rust-version: ["stable"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Check docs
         run: |
-          cargo build
+          sudo apt-get update && sudo apt-get install -y uuid-dev
           cargo test --doc
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         run: cargo clippy --all -- --deny warnings
 
       - name: Check docs
-        run: cargo test --doc
+        run: |
+          cargo build
+          cargo test --doc
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Build and Test
         run: |
-          cargo build --release
-          cargo test -- --nocapture
+          cargo build --workspace --release
+          cargo test --workspace -- --nocapture
 
       - name: Run cargo-release for specified version
         env:

--- a/.justfile
+++ b/.justfile
@@ -31,11 +31,11 @@ clean:
 
 # Build the project in debug mode
 build:
-  COPY_BINDINGS=true cargo build --all-targets
+  COPY_BINDINGS=true cargo build --workspace --all-targets
 
 # Build the project in release mode
 release:
-  cargo build --all-targets --release
+  cargo build --workspace --all-targets --release
 
 # Run the Aeron archive driver using Java
 run-aeron-archive-driver:

--- a/rusteron-archive/Cargo.toml
+++ b/rusteron-archive/Cargo.toml
@@ -50,4 +50,6 @@ serial_test = { workspace = true }
 env_logger = "0.11"
 
 [features]
+# using static as different modules have different versions of aeron which don't seem to play nicely
+default = ["static"]
 static = []

--- a/rusteron-archive/build.rs
+++ b/rusteron-archive/build.rs
@@ -54,6 +54,7 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=bindings.h");
     println!("cargo:rerun-if-changed=aeron/version.txt");
+    println!("cargo:rerun-if-changed=.git");
 
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");

--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -565,10 +565,13 @@ mod tests {
 
         let mut counter_id = -1;
 
-        while counter_id <= 0 {
+        let start = Instant::now();
+        while counter_id <= 0 && start.elapsed() < Duration::from_secs(5) {
             let counter_id = RecordingPos::find_counter_id_by_session(&counters_reader, session_id);
             info!("counter id {}", counter_id);
         }
+
+        assert!(counter_id >= 0);
 
         info!("counter id {counter_id}, session id {session_id}");
         while counters_reader.get_counter_value(counter_id) < stop_position {

--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -567,7 +567,7 @@ mod tests {
 
         let start = Instant::now();
         while counter_id <= 0 && start.elapsed() < Duration::from_secs(5) {
-            let counter_id = RecordingPos::find_counter_id_by_session(&counters_reader, session_id);
+            counter_id = RecordingPos::find_counter_id_by_session(&counters_reader, session_id);
             info!("counter id {}", counter_id);
         }
 

--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -548,9 +548,11 @@ mod tests {
                     panic!("{}", err);
                 }
             }
-            info!("sent message {i}");
+            info!("sent message {i} [test_aeron_archive]");
         }
 
+        let session_id = publication.get_constants()?.session_id;
+        info!("publication session id {}", session_id);
         // since this is single threaded need to make sure it did write to archiver, usually not required in multi-proccess app
         let stop_position = publication.position();
         info!(
@@ -560,10 +562,13 @@ mod tests {
         );
         let counters_reader = aeron.counters_reader();
         info!("counters reader ready {:?}", counters_reader);
-        let session_id = publication.get_constants()?.session_id;
-        info!("session id {}", session_id);
-        let counter_id = RecordingPos::find_counter_id_by_session(&counters_reader, session_id);
-        info!("counter id {}", counter_id);
+
+        let mut counter_id = -1;
+
+        while counter_id <= 0 {
+            let counter_id = RecordingPos::find_counter_id_by_session(&counters_reader, session_id);
+            info!("counter id {}", counter_id);
+        }
 
         info!("counter id {counter_id}, session id {session_id}");
         while counters_reader.get_counter_value(counter_id) < stop_position {

--- a/rusteron-archive/src/testing.rs
+++ b/rusteron-archive/src/testing.rs
@@ -286,7 +286,7 @@ impl EmbeddedArchiveMediaDriverProcess {
             &format!("-Daeron.dir={}", aeron_dir),
             &format!("-Daeron.archive.dir={}", archive_dir),
             "-Daeron.spies.simulate.connection=true",
-            "-Daeron.event.log=admin,replay", // this will only work if an agent is built
+            "-Daeron.event.log=admin", // this will only work if an agent is built
             "-Daeron.event.archive.log=all",
             "-Daeron.event.cluster.log=all",
             // "-Daeron.term.buffer.sparse.file=false",

--- a/rusteron-client/Cargo.toml
+++ b/rusteron-client/Cargo.toml
@@ -60,7 +60,8 @@ criterion = {workspace = true}
 env_logger = "0.11"
 
 [features]
-default = []
+# using static as different modules have different versions of aeron which don't seem to play nicely
+default = ["static"]
 static = ["rusteron-media-driver/static"]
 
 [[bench]]

--- a/rusteron-client/build.rs
+++ b/rusteron-client/build.rs
@@ -39,6 +39,7 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=bindings.h");
     println!("cargo:rerun-if-changed=aeron/version.txt");
+    println!("cargo:rerun-if-changed=.git");
 
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");

--- a/rusteron-code-gen/Cargo.toml
+++ b/rusteron-code-gen/Cargo.toml
@@ -21,4 +21,5 @@ log = "0.4"
 trybuild = "1.0"
 
 [features]
+default = ["static"]
 static = []

--- a/rusteron-docker-samples/pod.yml
+++ b/rusteron-docker-samples/pod.yml
@@ -19,7 +19,7 @@ spec:
         - name: "AERON_PRINT_CONFIGURATION"
           value: "true"
         - name: "AERON_EVENT_LOG"
-#          value: "admin,replay"
+#          value: "admin"
           value: "all"
         - name: "AERON_EVENT_ARCHIVE_LOG"
           value: "all"

--- a/rusteron-docker-samples/rusteron-dummy-example/Dockerfile
+++ b/rusteron-docker-samples/rusteron-dummy-example/Dockerfile
@@ -29,4 +29,5 @@ ARG BUILD_DIR_NAME=debug
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/ticker_reader /usr/local/bin/ticker_reader
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/ticker_writer /usr/local/bin/ticker_writer
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/build/rusteron-archive-*/out/build/lib/*.so /usr/lib
+COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/build/rusteron-archive-*/out/build/lib/*.a /usr/lib
 

--- a/rusteron-docker-samples/rusteron-dummy-example/Dockerfile
+++ b/rusteron-docker-samples/rusteron-dummy-example/Dockerfile
@@ -28,6 +28,5 @@ ARG BUILD_DIR_NAME=debug
 
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/ticker_reader /usr/local/bin/ticker_reader
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/ticker_writer /usr/local/bin/ticker_writer
-COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/build/rusteron-archive-*/out/build/lib/*.so /usr/lib
 COPY --from=builder /usr/src/app/target/${BUILD_DIR_NAME}/build/rusteron-archive-*/out/build/lib/*.a /usr/lib
 

--- a/rusteron-media-driver/Cargo.toml
+++ b/rusteron-media-driver/Cargo.toml
@@ -51,7 +51,8 @@ log = { workspace = true}
 regex = { workspace = true}
 
 [features]
-default=[]
+# using static as different modules have different versions of aeron which don't seem to play nicely
+default=["static"]
 static=[]
 
 [[bin]]

--- a/rusteron-media-driver/build.rs
+++ b/rusteron-media-driver/build.rs
@@ -39,6 +39,7 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=bindings.h");
     println!("cargo:rerun-if-changed=aeron/version.txt");
+    println!("cargo:rerun-if-changed=.git");
 
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");

--- a/rusteron-rb/Cargo.toml
+++ b/rusteron-rb/Cargo.toml
@@ -50,4 +50,6 @@ log = { workspace = true}
 regex = { workspace = true}
 
 [features]
+# using static as different modules have different versions of aeron which don't seem to play nicely
+default = ["static"]
 static = []


### PR DESCRIPTION
Fix build issues with different version libs. For some reason why using dynamic libs instead of static, since rusteron-archive usess master/1.47.0 but when rusteron-client which uses aeron branch 1.46.7 it seems to pick up the dynamic libs of 1.47.0.

So for now I made only static libraries available until we get to a stage where all modules use the same version of aeron we can add back dynamic libs