### PR TITLE
Issue 37 drop seg fault

### DIFF
--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -20,7 +20,6 @@ pub mod bindings {
 
 use bindings::*;
 use std::cell::Cell;
-use std::ops::Sub;
 use std::os::raw::c_int;
 use std::time::{Duration, Instant};
 
@@ -213,6 +212,9 @@ macro_rules! impl_archive_position_methods {
 impl_archive_position_methods!(AeronPublication);
 impl_archive_position_methods!(AeronExclusivePublication);
 
+const NO_OP_AERON_IDEL_STRAT_HANDLER: std::sync::LazyLock<Handler<NoOpAeronIdleStrategyFunc>> =
+    std::sync::LazyLock::new(|| Handler::leak(NoOpAeronIdleStrategyFunc));
+
 impl AeronArchiveContext {
     // The method below sets no credentials supplier, which is essential for the operation
     // of the Aeron Archive Context. The `set_credentials_supplier` must be set to prevent
@@ -241,7 +243,7 @@ impl AeronArchiveContext {
         context.set_control_response_channel(response_control_channel)?;
         context.set_recording_events_channel(recording_events_channel)?;
         // see https://github.com/mimran1980/rusteron/issues/18
-        context.set_idle_strategy(Some(&Handler::leak(NoOpAeronIdleStrategyFunc)))?;
+        context.set_idle_strategy(Some(&NO_OP_AERON_IDEL_STRAT_HANDLER))?;
         Ok(context)
     }
 }
@@ -615,25 +617,6 @@ mod tests {
         assert_eq!(aeron_version, cargo_version);
     }
 
-    // #[test]
-    // #[serial]
-    // pub fn test_failed_connect() -> Result<(), Box<dyn error::Error>> {
-    //         env_logger::Builder::new()
-    //         .is_test(true)
-    //         .filter_level(log::LevelFilter::Info)
-    //         .init();
-    //     let ctx = AeronArchiveContext::new()?;
-    //     std::env::set_var("AERON_DRIVER_TIMEOUT", "1");
-    //     let connect = AeronArchiveAsyncConnect::new(&ctx);
-    //     std::env::remove_var("AERON_DRIVER_TIMEOUT");
-    //
-    //     assert_eq!(
-    //         Some(AeronErrorType::NullOrNotConnected.into()),
-    //         connect.err()
-    //     );
-    //     Ok(())
-    // }
-
     use std::thread;
 
     pub fn start_aeron_archive() -> Result<
@@ -837,11 +820,12 @@ mod tests {
         info!("archive id: {}", archive.get_archive_id());
 
         info!("add subscription {}", channel_replay);
+        let available_handler = Handler::leak(AeronAvailableImageLogger);
         let subscription = aeron
             .async_add_subscription(
                 &channel_replay,
                 replay_stream_id,
-                Some(&Handler::leak(AeronAvailableImageLogger)),
+                Some(&available_handler),
                 Some(&Handler::leak(AeronUnavailableImageLogger)),
             )?
             .poll_blocking(Duration::from_secs(10))?;
@@ -860,7 +844,8 @@ mod tests {
             }
         }
 
-        let poll = Handler::leak(FragmentHandler::default());
+        let handler = FragmentHandler::default();
+        let poll = Handler::leak(handler);
 
         let start = Instant::now();
         while start.elapsed() < Duration::from_secs(10) && subscription.poll(Some(&poll), 100)? <= 0

--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -204,7 +204,7 @@ impl AeronPublication {
         if position < 0 {
             return false;
         }
-        self.position().sub(position) <= length_inclusive as i64
+        self.position().sub(position) >= length_inclusive as i64
     }
 }
 
@@ -244,11 +244,11 @@ impl AeronExclusivePublication {
 
     /// Checks if the publication's current position is within a specified inclusive length of the archive position.
     pub fn is_archive_position_with(&self, length_inclusive: usize) -> bool {
-        let position = self.get_archive_position().unwrap_or(-1);
-        if position < 0 {
+        let archive_position = self.get_archive_position().unwrap_or(-1);
+        if archive_position < 0 {
             return false;
         }
-        self.position().sub(position) <= length_inclusive as i64
+        self.position().sub(archive_position) >= length_inclusive as i64
     }
 }
 

--- a/rusteron-client/src/lib.rs
+++ b/rusteron-client/src/lib.rs
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     #[serial]
-    pub fn should_be_able_to_drop_after_close_manually_being_called(
+    pub fn should_be_able_to_drop_after_close_manually_being_closed(
     ) -> Result<(), Box<dyn error::Error>> {
         let _ = env_logger::Builder::new()
             .is_test(true)

--- a/rusteron-code-gen/src/common.rs
+++ b/rusteron-code-gen/src/common.rs
@@ -524,6 +524,9 @@ pub(crate) mod test_alloc {
     use std::sync::atomic::{AtomicIsize, Ordering};
 
     /// A simple global allocator that tracks the net allocation count.
+    /// For very simple examples can do allocation count before and after your test.
+    /// This does not work well with logger, running media driver, etc. Only for the most
+    /// basic controlled examples
     pub struct CountingAllocator {
         allocs: AtomicIsize,
     }

--- a/rusteron-code-gen/src/common.rs
+++ b/rusteron-code-gen/src/common.rs
@@ -380,8 +380,11 @@ impl std::error::Error for AeronCError {}
 ///
 /// `Handler` is a struct that wraps a raw pointer and a drop flag.
 ///
-/// **Important:** `Handler` does not get dropped automatically.
+/// **Important:** `Handler` *MAY* not get dropped automatically. It depends if aeron takes ownership.
+/// For example for global level handlers e.g. error handler aeron will release this handle when closing.
+///
 /// You need to call the `release` method if you want to clear the memory manually.
+/// Its important that you test this out as aeron may do it when closing aeron client.
 ///
 /// ## Example
 ///
@@ -514,7 +517,7 @@ impl ControlMode {
 
 #[cfg(test)]
 #[allow(dead_code)]
-mod test_alloc {
+pub(crate) mod test_alloc {
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::sync::atomic::{AtomicIsize, Ordering};
 

--- a/rusteron-code-gen/src/common.rs
+++ b/rusteron-code-gen/src/common.rs
@@ -114,6 +114,7 @@ impl<T> ManagedCResource<T> {
         unsafe { &mut *self.resource }
     }
 
+    #[inline]
     // to prevent the dependencies from being dropped as you have a copy here
     pub fn add_dependency<D: std::any::Any>(&self, dep: D) {
         if let Some(dep) =
@@ -129,6 +130,7 @@ impl<T> ManagedCResource<T> {
         }
     }
 
+    #[inline]
     pub fn get_dependency<V: Clone + 'static>(&self) -> Option<V> {
         unsafe {
             (*self.dependencies.get())

--- a/rusteron-code-gen/src/common.rs
+++ b/rusteron-code-gen/src/common.rs
@@ -20,7 +20,9 @@ pub struct ManagedCResource<T> {
     check_for_is_closed: Option<Box<dyn Fn(*mut T) -> bool>>,
     /// this will be called if closed hasn't already happened even if its borrowed
     auto_close: std::cell::Cell<bool>,
-    // to prevent the dependencies from being dropped as you have a copy here
+    /// to prevent the dependencies from being dropped as you have a copy here,
+    /// for example, you want to have a dependency to aeron for any async jobs so aeron doesnt get dropped first
+    /// when you have a publication/subscription
     dependencies: UnsafeCell<Vec<std::rc::Rc<dyn std::any::Any>>>,
 }
 

--- a/rusteron-code-gen/src/generator.rs
+++ b/rusteron-code-gen/src/generator.rs
@@ -624,7 +624,7 @@ impl CWrapper {
                 // getter methods
                 Self::add_getter_instead_of_mut_arg_if_applicable(wrappers, method, &fn_name, &where_clause, &possible_self, &method_docs, &mut additional_methods);
 
-                Self::add_once_methods_for_handlers(closure_handlers, method, &fn_name, &return_type, &ffi_call, &where_clause, &fn_arguments, &mut arg_names, &converter, &possible_self, &method_docs, &mut additional_methods);
+                Self::add_once_methods_for_handlers(closure_handlers, method, &fn_name, &return_type, &ffi_call, &where_clause, &fn_arguments, &mut arg_names, &converter, &possible_self, &method_docs, &mut additional_methods, &set_closed);
 
                 let mut_primitivies = method.arguments.iter()
                     .filter(|a| a.is_mut_pointer() && a.is_primitive())
@@ -725,6 +725,7 @@ impl CWrapper {
         possible_self: &TokenStream,
         method_docs: &Vec<TokenStream>,
         additional_methods: &mut Vec<TokenStream>,
+        set_closed: &TokenStream,
     ) {
         if method.arguments.iter().any(|arg| {
             matches!(arg.processing, ArgProcessing::Handler(_))
@@ -812,6 +813,7 @@ impl CWrapper {
                 /// _NOTE: aeron must not store this closure and instead use it immediately. If not you will get undefined behaviour,
                 ///  use with care_
                 pub fn #fn_name #where_clause(#possible_self #(#fn_arguments),*) -> #return_type {
+                    #set_closed
                     unsafe {
                         let result = #ffi_call(#(#arg_names),*);
                         #converter


### PR DESCRIPTION
* helps with issues raised from [37](https://github.com/mimran1980/rusteron/issues/37) where it was possible to segfault on a drop.

I wrote some unit tests to covert the different variations of close and ensure drop does not cause segfault.

However I was not able to replication the issues he mentioned apart from it segfaulting after you manually called close which is expected behaviour. Either way added more unit tests and cleaned up code.

* Also added some helper methods on publication to get the archive position 